### PR TITLE
feat: Enhance carousel with variable chunking and default displayLength

### DIFF
--- a/examples/district/components/Carousel/Carousel.tsx
+++ b/examples/district/components/Carousel/Carousel.tsx
@@ -58,33 +58,19 @@ export function SummaryCarousel({
           prevBtn={<IconArrowLeft />}
           current={current}
         >
-          <ul>
-            {a?.map((item: any, index: any) => (
-              <li key={`summary-${index}`}>
-                <div></div>
-                <strong>{item.value}</strong>
-                <span>{item.text}</span>
-              </li>
-            ))}
-          </ul>
-          <ul>
-            {b?.map((item: any, index: any) => (
-              <li key={`summary-${index}`}>
-                <div></div>
-                <strong>{item.value}</strong>
-                <span>{item.text}</span>
-              </li>
-            ))}
-          </ul>
-          <ul>
-            {c?.map((item: any, index: any) => (
-              <li key={`summary-${index}`}>
-                <div></div>
-                <strong>{item.value}</strong>
-                <span>{item.text}</span>
-              </li>
-            ))}
-          </ul>
+          {Object.keys(chunkedVariables).map((variableName) => (
+            <ul key={`list-${variableName}`}>
+              {chunkedVariables[variableName]?.map(
+                (item: any, index: number) => (
+                  <li key={`summary-${variableName}-${index}`}>
+                    <div></div>
+                    <strong>{item.value}</strong>
+                    <span>{item.text}</span>
+                  </li>
+                )
+              )}
+            </ul>
+          ))}
         </Carousel>
       </div>
     </Box>

--- a/examples/district/components/Carousel/Carousel.tsx
+++ b/examples/district/components/Carousel/Carousel.tsx
@@ -6,8 +6,10 @@ import styles from './carousel.module.scss';
 
 export function SummaryCarousel({
   indicatorList,
+  displayLength = 8,
 }: {
   indicatorList: { text: string; value: string }[];
+  displayLength?: number;
 }) {
   const [currentSlide, setCurrentSlide] = React.useState(1);
   const [childrenLength, setChildrenLength] = React.useState(3);
@@ -28,9 +30,16 @@ export function SummaryCarousel({
     return chunks;
   }
 
-  let a: any, b: any, c: any;
+  const variableNames = Array.from({ length: 26 }, (_, i) =>
+    String.fromCharCode(97 + i)
+  );
 
-  [a, b, c] = chunk(indicatorList, 8);
+  const chunks = chunk(indicatorList, displayLength);
+  const chunkedVariables: any = {};
+
+  for (let i = 0; i < chunks.length && i < variableNames.length; i++) {
+    chunkedVariables[variableNames[i]] = chunks[i];
+  }
 
   return (
     <Box padding="5">


### PR DESCRIPTION
@PixeledCode here, enhanced the functionality of the SummaryCarousel component to support dynamic variable chunking. Previously, the component relied on manually defined variables (a, b, c) to split and render the indicatorList. Now, I've added more flexibility by allowing the displayLength to be passed as a prop, which determines the number of items in each chunk.
and 
replaced repetitive code for each variable (a, b, c) with dynamic rendering through mapping.