### PR TITLE
fix(opub-ui): stop shipping source maps that reference missing sources

### DIFF
--- a/packages/opub-ui/rollup.config.mjs
+++ b/packages/opub-ui/rollup.config.mjs
@@ -31,7 +31,7 @@ const rollup = (_args) => {
       format: 'esm',
       preserveModules: true,
       preserveModulesRoot: 'src',
-      sourcemap: true,
+      sourcemap: false,
     },
     plugins: getPlugins(),
     external,
@@ -65,6 +65,7 @@ const getPlugins = () => {
     ],
     compilerOptions: {
       rootDir: 'src',
+      sourceMap: false,
     },
   };
 

--- a/packages/opub-ui/tsconfig.node.json
+++ b/packages/opub-ui/tsconfig.node.json
@@ -1,5 +1,9 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "sourceMap": false
+  },
   "exclude": [
     "dist",
     "build",


### PR DESCRIPTION
Published .js.map files pointed at TypeScript sources under ../../src/...
that aren't included in the tarball, and every emitted .js (including the
*.module.scss.js CSS-module stubs) ended with a //# sourceMappingURL=...
comment. Consumers saw:

- Browser 404s for *.module.scss.js.map in Next.js apps, because Next.js
  forwards the sourceMappingURL comment into its own bundled chunks.
- "Failed to parse source map ... ENOENT" warnings from webpack's
  source-map-loader for every opub-ui file.

Disable source-map emission on the publish build:

- rollup.config.mjs: output.sourcemap -> false, plus sourceMap: false in
  the @rollup/plugin-typescript compilerOptions to silence the
  mismatched-settings warning it otherwise prints.
- tsconfig.node.json: emitDeclarationOnly: true and sourceMap: false.
  build:types was emitting an unused .js + .js.map shadow tree (270 files)
  under dist/src/ that nothing in the exports map referenced.

Verified via npm pack --dry-run: no .map files and no sourceMappingURL
comments in the tarball; dist/ts/ declarations and the extracted
dist/assets/styles-bundled.css are unchanged.
