### PR TITLE
feat(ProgressBar): Show the right fill immediately, and update on value change

### DIFF
--- a/packages/opub-ui/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/opub-ui/src/components/ProgressBar/ProgressBar.tsx
@@ -15,11 +15,10 @@ const ProgressBar = forwardRef(
       animated = true,
       ...others
     } = props;
-    const [progress, setProgress] = React.useState(0);
+    const [progress, setProgress] = React.useState(value);
     React.useEffect(() => {
-      const timer = setTimeout(() => setProgress(value), 500);
-      return () => clearTimeout(timer);
-    }, []);
+      setProgress(value);
+    }, [value]);
 
     const themeClass = cn(
       styles.Root,


### PR DESCRIPTION
Previously, the bar always started at 0 and slid to its target after a
half-second delay. And if the value later changed, the bar didn't update;
it stayed pinned to whatever it was when it first appeared.

Now, the bar shows the correct amount as soon as it's drawn, and animates
smoothly to the new amount whenever the value changes.

This also makes the interface feel snappier.
