### PR TITLE
i18n(MultiMonthPicker): Localize label and fix UTC off-by-one error

### DIFF
--- a/packages/opub-ui/src/components/DatePicker/MultiMonthPicker.tsx
+++ b/packages/opub-ui/src/components/DatePicker/MultiMonthPicker.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { DateValue } from '@react-types/calendar';
 import { IconCalendar } from '@tabler/icons-react';
-import { useDatePicker } from 'react-aria';
+import { useDateFormatter, useDatePicker } from 'react-aria';
 import { useDatePickerState } from 'react-stately';
 
 import { cn } from '../../utils';
@@ -63,6 +63,11 @@ const MultiMonthPicker = React.forwardRef(
       useDatePicker(props, state, ref);
     const themeClass = cn(styles.DatePicker);
 
+    const monthFormatter = useDateFormatter({
+      month: 'short',
+      year: 'numeric',
+    });
+
     const {
       onPress: onPressPrev,
       isDisabled: disabledPrev,
@@ -101,10 +106,9 @@ const MultiMonthPicker = React.forwardRef(
                       selectedValues?.length > 0
                         ? selectedValues
                             .map((date) =>
-                              new Intl.DateTimeFormat('en-US', {
-                                month: 'short',
-                                year: 'numeric',
-                              }).format(new Date(date.toString()))
+                              monthFormatter.format(
+                                new Date(date.year, date.month - 1, date.day)
+                              )
                             )
                             .join(', ')
                         : ''


### PR DESCRIPTION
The locale now comes from the nearest `<I18nProvider>` (falling back to the runtime locale).

`new Date(date.toString())` parses to UTC midnight. If the browser's local timezone is behind UTC, the month label reads one month early.

Example bug (India is ahead of UTC, so this bug isn't reproducible there without changing timezone):

<img width="290" height="274" alt="Screenshot 2026-05-27 at 10 52 34 PM" src="https://github.com/user-attachments/assets/1798f7c2-ab29-42d0-8aa1-3a4ec4967ef3" />
