### PR TITLE
fix: Update URL for OpenStreetMap tile layer

### DIFF
--- a/packages/opub-ui/src/components/MapChart/MapChart.tsx
+++ b/packages/opub-ui/src/components/MapChart/MapChart.tsx
@@ -41,7 +41,7 @@ const OSM_ATTRIBUTION =
  */
 const defaultLayers: Record<string, TileLayerConfig> = {
   light: {
-    url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
     attribution: OSM_ATTRIBUTION,
   },
 };


### PR DESCRIPTION
This was using an old URL: https://wiki.openstreetmap.org/wiki/Raster_tile_providers

> Other subdomains or hostnames may be slower or withdrawn without notice.

https://operations.osmfoundation.org/policies/tiles/