### PR TITLE
a11y(DatePicker): surface react-aria out-of-range validation

### DIFF
--- a/packages/opub-ui/src/components/DateField/DateField.tsx
+++ b/packages/opub-ui/src/components/DateField/DateField.tsx
@@ -132,11 +132,22 @@ export function DateFieldSegment({ segment, state }: DatePickerSegmentProps) {
 type RangeProps = {
   startFieldProps: AriaDatePickerProps<DateValue>;
   endFieldProps: AriaDatePickerProps<DateValue>;
+  errorMessage?: React.ReactNode;
 };
 
-const DateRangeField = ({ startFieldProps, endFieldProps }: RangeProps) => {
+const DateRangeField = ({
+  startFieldProps,
+  endFieldProps,
+  errorMessage,
+}: RangeProps) => {
   return (
-    <div className={cn(styles.RangeField, inputStyles.TextField)}>
+    <div
+      className={cn(
+        styles.RangeField,
+        inputStyles.TextField,
+        Boolean(errorMessage) && inputStyles.error
+      )}
+    >
       <DateField isPicker trim isRange {...startFieldProps} />
       <span>{'-'}</span>
       <DateField isPicker trim isRange {...endFieldProps} />

--- a/packages/opub-ui/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/opub-ui/src/components/DatePicker/DatePicker.stories.tsx
@@ -76,6 +76,21 @@ export const MultipleMonths: Story = {
   },
 };
 
+/**
+ * An out-of-range value surfaces react-aria's validation as an error and sets
+ * `aria-invalid` on the field segments — even though no `error` prop is passed.
+ * Here the default (Jan 2025) is past `maxValue` (Apr 2024).
+ */
+export const MonthOutOfRange: Story = {
+  render: ({ ...args }) => <MonthPicker {...args} />,
+  args: {
+    label: 'Month Picker',
+    defaultValue: parseDate('2025-01-01'),
+    minValue: parseDate('2023-02-01'),
+    maxValue: parseDate('2024-04-01'),
+  },
+};
+
 export const DisabledDates: StoryRange = {
   ...Range,
   args: {

--- a/packages/opub-ui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/opub-ui/src/components/DatePicker/DatePicker.tsx
@@ -14,6 +14,7 @@ import inputStyles from '../Input/Input.module.scss';
 import { Labelled, LabelledProps } from '../Labelled';
 import { Popover } from '../Popover';
 import styles from './DatePicker.module.scss';
+import { resolveDateError } from './validation';
 
 export type DatePickerProps = {
   /** Label for the field */
@@ -53,9 +54,18 @@ const DatePicker = React.forwardRef(
     
     let state = useDatePickerState(stateProps);
 
-    let { labelProps, fieldProps, buttonProps, dialogProps, calendarProps } =
-      useDatePicker(stateProps, state, ref);
+    let {
+      labelProps,
+      fieldProps,
+      buttonProps,
+      dialogProps,
+      calendarProps,
+      isInvalid,
+      validationErrors,
+    } = useDatePicker(stateProps, state, ref);
     const themeClass = cn(styles.DatePicker);
+
+    const displayedError = resolveDateError(error, isInvalid, validationErrors);
 
     const {
       onPress: onPressPrev,
@@ -68,14 +78,14 @@ const DatePicker = React.forwardRef(
         <Labelled
           label={props.label}
           {...labelProps}
-          error={error}
+          error={displayedError}
           action={labelAction}
           labelHidden={labelHidden}
           helpText={helpText}
           requiredIndicator={requiredIndicator}
         >
           <div ref={ref} className={styles.Wrapper}>
-            <DateField errorMessage={error} isPicker {...fieldProps} />
+            <DateField isPicker {...fieldProps} errorMessage={displayedError} />
             <Popover
               onOpenChange={() =>
                 !state.isOpen ? state.open() : state.close()

--- a/packages/opub-ui/src/components/DatePicker/DateRangePicker.tsx
+++ b/packages/opub-ui/src/components/DatePicker/DateRangePicker.tsx
@@ -16,6 +16,7 @@ import inputStyles from '../Input/Input.module.scss';
 import { Labelled } from '../Labelled';
 import { Popover } from '../Popover';
 import styles from './DatePicker.module.scss';
+import { resolveDateError } from './validation';
 
 export type RangePickerProps = {
   label: string;
@@ -51,8 +52,16 @@ const DateRangePicker = React.forwardRef(
       buttonProps,
       dialogProps,
       calendarProps,
+      isInvalid,
+      validationErrors,
     } = useDateRangePicker(stateProps, state, ref);
     const themeClass = cn(styles.DatePicker);
+
+    const displayedError = resolveDateError(
+      errorMessage,
+      isInvalid,
+      validationErrors
+    );
 
     const {
       onPress: onPressPrev,
@@ -63,7 +72,7 @@ const DateRangePicker = React.forwardRef(
     return (
       <div className={`opub-DatePicker ${themeClass}`}>
         <Labelled
-          error={state.isInvalid && errorMessage}
+          error={displayedError}
           label={label}
           helpText={helpText}
           labelHidden={labelHidden}
@@ -75,6 +84,7 @@ const DateRangePicker = React.forwardRef(
             <DateRangeField
               startFieldProps={startFieldProps}
               endFieldProps={endFieldProps}
+              errorMessage={displayedError}
             />
 
             <Popover

--- a/packages/opub-ui/src/components/DatePicker/MonthPicker.tsx
+++ b/packages/opub-ui/src/components/DatePicker/MonthPicker.tsx
@@ -14,6 +14,7 @@ import inputStyles from '../Input/Input.module.scss';
 import { Labelled, LabelledProps } from '../Labelled';
 import { Popover } from '../Popover';
 import styles from './DatePicker.module.scss';
+import { resolveDateError } from './validation';
 
 export type DatePickerProps = {
   /** Label for the field */
@@ -51,9 +52,18 @@ const MonthPicker = ({
 
   let state = useDatePickerState(processedProps);
 
-  let { labelProps, fieldProps, buttonProps, dialogProps, calendarProps } =
-    useDatePicker(processedProps, state, ref);
+  let {
+    labelProps,
+    fieldProps,
+    buttonProps,
+    dialogProps,
+    calendarProps,
+    isInvalid,
+    validationErrors,
+  } = useDatePicker(processedProps, state, ref);
   const themeClass = cn(styles.DatePicker);
+
+  const displayedError = resolveDateError(error, isInvalid, validationErrors);
 
   const {
     onPress: onPressPrev,
@@ -66,7 +76,7 @@ const MonthPicker = ({
       <Labelled
         label={props.label}
         {...labelProps}
-        error={error}
+        error={displayedError}
         action={labelAction}
         labelHidden={labelHidden}
         helpText={helpText}
@@ -75,7 +85,7 @@ const MonthPicker = ({
         <div ref={ref} className={styles.Wrapper}>
           <DateField
             {...fieldProps}
-            errorMessage={error}
+            errorMessage={displayedError}
             isPicker
             granularity="month"
           />

--- a/packages/opub-ui/src/components/DatePicker/validation.ts
+++ b/packages/opub-ui/src/components/DatePicker/validation.ts
@@ -1,0 +1,13 @@
+import React from 'react';
+
+/** Consumer error wins; otherwise surface react-aria's validation message (or a default) when invalid. */
+export function resolveDateError(
+  consumerError: React.ReactNode,
+  isInvalid: boolean,
+  validationErrors: string[],
+  fallback: React.ReactNode = 'The selected date is out of range.'
+): React.ReactNode {
+  if (consumerError) return consumerError;
+  if (!isInvalid) return undefined;
+  return validationErrors.length > 0 ? validationErrors.join(' ') : fallback;
+}


### PR DESCRIPTION
Closes CivicDataLab/IDS-DRR-Frontend#506

However, this is a behavior change that you'll want to decide on.

Date pickers now show an error when the entered value is outside minValue/maxValue. Before, an out-of-range value was silently accepted with no visible error; now the field turns red and shows react-aria's validation message automatically, even if you didn't pass an error prop.
