### PR TITLE
feat(index): export types from the index file

### DIFF
--- a/packages/opub-ui/src/index.ts
+++ b/packages/opub-ui/src/index.ts
@@ -1,3 +1,4 @@
 import '../assets/styles-bundled.css';
 
 export * from './components';
+export * from './types';


### PR DESCRIPTION
- Added export for types from the './types' module in the index.ts file, enhancing the module's usability by making types available for import.